### PR TITLE
Add Sobol and Halton quasi-random orientation sampling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -765,6 +765,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "sobol_burley",
  "tikv-jemallocator",
  "tobj",
  "toml 0.8.23",
@@ -1992,6 +1993,12 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "sobol_burley"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f37cae1d97c4078377153ede7a26f7813b689ad5c6b76ff45dc52e53afe1d1"
 
 [[package]]
 name = "spade"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@
     pyo3-stub-gen = { version = "0.17", optional = true }
     rand = "0.9.0"
     rand_distr = "0.5.1"
+    sobol_burley = "0.5"
     rayon = "1.10.0"
     serde = { version = "1.0.217", features = ["derive"] }
     serde_json = "1.0.140"

--- a/src/convergence.rs
+++ b/src/convergence.rs
@@ -17,7 +17,7 @@ use rand::rngs::StdRng;
 use crate::{
     geom::Geom,
     multiproblem::{init_result, load_and_init_geoms, load_settings_or_default},
-    orientation::{Euler, OrientationSampler},
+    orientation::{Euler, OrientationSampler, Scheme},
     output,
     params::Param,
     problem::Problem,
@@ -81,8 +81,13 @@ impl Convergence {
             rand::rngs::StdRng::from_rng(&mut rand::rng())
         };
 
-        // Convergence always uses uniform random sampling (infinite supply)
-        let sampler = OrientationSampler::uniform(settings.seed);
+        // Create sampler based on scheme setting
+        let sampler = match &settings.orientation.scheme {
+            Scheme::Uniform { .. } => OrientationSampler::uniform(settings.seed),
+            Scheme::Discrete { eulers } => OrientationSampler::discrete(eulers.clone()),
+            Scheme::Sobol { .. } => OrientationSampler::sobol(settings.seed),
+            Scheme::Halton { .. } => OrientationSampler::halton(),
+        };
 
         Ok(Self {
             geoms,

--- a/src/convergence/python.rs
+++ b/src/convergence/python.rs
@@ -5,7 +5,7 @@ use rand::SeedableRng;
 
 use crate::geom::Geom;
 use crate::multiproblem::init_result;
-use crate::orientation::OrientationSampler;
+use crate::orientation::{OrientationSampler, Scheme};
 use crate::params::Param;
 use crate::problem::init_geom;
 use crate::result::Results;
@@ -38,8 +38,13 @@ impl Convergence {
 
         let template = init_result(&settings);
 
-        // Convergence always uses uniform random sampling (infinite supply)
-        let sampler = OrientationSampler::uniform(settings.seed);
+        // Create sampler based on scheme setting
+        let sampler = match &settings.orientation.scheme {
+            Scheme::Uniform { .. } => OrientationSampler::uniform(settings.seed),
+            Scheme::Discrete { eulers } => OrientationSampler::discrete(eulers.clone()),
+            Scheme::Sobol { .. } => OrientationSampler::sobol(settings.seed),
+            Scheme::Halton { .. } => OrientationSampler::halton(),
+        };
 
         let rng = if let Some(seed) = settings.seed {
             rand::rngs::StdRng::seed_from_u64(seed)

--- a/src/orientation.rs
+++ b/src/orientation.rs
@@ -22,6 +22,12 @@ pub enum Scheme {
     /// Solve the problem by averaging over a discrete set of angles (in degrees).
     /// Example: `discrete 0,0,0 20,30,40`
     Discrete { eulers: Vec<Euler> },
+    /// Solve the problem using Sobol quasi-random sequence for faster convergence.
+    /// Example: `sobol 100`
+    Sobol { num_orients: usize },
+    /// Solve the problem using Halton quasi-random sequence for faster convergence.
+    /// Example: `halton 100`
+    Halton { num_orients: usize },
 }
 
 /// Euler angle order for the discrete orientation scheme.
@@ -298,12 +304,44 @@ impl Orientation {
         }
     }
 
+    #[staticmethod]
+    #[pyo3(name = "sobol", signature = (num_orients, euler_convention = None))]
+    fn py_sobol(num_orients: usize, euler_convention: Option<EulerConvention>) -> Self {
+        Orientation {
+            scheme: Scheme::Sobol { num_orients },
+            euler_convention: euler_convention.unwrap_or(DEFAULT_EULER_ORDER),
+        }
+    }
+
+    #[staticmethod]
+    #[pyo3(name = "halton", signature = (num_orients, euler_convention = None))]
+    fn py_halton(num_orients: usize, euler_convention: Option<EulerConvention>) -> Self {
+        Orientation {
+            scheme: Scheme::Halton { num_orients },
+            euler_convention: euler_convention.unwrap_or(DEFAULT_EULER_ORDER),
+        }
+    }
+
     fn __repr__(&self) -> String {
         format!(
             "Orientation(scheme={:?}, euler_convention={:?})",
             self.scheme, self.euler_convention
         )
     }
+}
+
+/// Compute the Halton sequence value for a given index and base.
+/// Returns a value in [0, 1).
+fn halton_sequence(index: u32, base: u32) -> f32 {
+    let mut result = 0.0;
+    let mut f = 1.0 / base as f32;
+    let mut i = index;
+    while i > 0 {
+        result += f * (i % base) as f32;
+        i /= base;
+        f /= base as f32;
+    }
+    result
 }
 
 /// Orientation sampler that generates orientations on demand.
@@ -315,6 +353,10 @@ pub enum OrientationSampler {
     },
     /// Iterates over a discrete set of orientations.
     Discrete { eulers: Vec<Euler>, index: usize },
+    /// Generates orientations using Sobol quasi-random sequence (never exhausts).
+    Sobol { seed: u32, index: u32 },
+    /// Generates orientations using Halton quasi-random sequence (never exhausts).
+    Halton { index: u32 },
 }
 
 impl OrientationSampler {
@@ -331,6 +373,19 @@ impl OrientationSampler {
     /// Create a discrete sampler from a list of Euler angles.
     pub fn discrete(eulers: Vec<Euler>) -> Self {
         Self::Discrete { eulers, index: 0 }
+    }
+
+    /// Create a Sobol quasi-random sampler.
+    pub fn sobol(seed: Option<u64>) -> Self {
+        Self::Sobol {
+            seed: seed.unwrap_or(0) as u32,
+            index: 0,
+        }
+    }
+
+    /// Create a Halton quasi-random sampler.
+    pub fn halton() -> Self {
+        Self::Halton { index: 0 }
     }
 
     /// Get the next orientation. Returns None if exhausted (for discrete samplers).
@@ -351,6 +406,29 @@ impl OrientationSampler {
                     None
                 }
             }
+            Self::Sobol { seed, index } => {
+                let u1 = sobol_burley::sample(*index, 0, *seed);
+                let u2 = sobol_burley::sample(*index, 1, *seed);
+                let u3 = sobol_burley::sample(*index, 2, *seed);
+                *index += 1;
+
+                let alpha = u1 * 360.0;
+                let beta = (1.0_f32 - u2 * 2.0).acos() * 180.0 / PI;
+                let gamma = u3 * 360.0;
+                Some(Euler::new(alpha, beta, gamma))
+            }
+            Self::Halton { index } => {
+                // Use primes 2, 3, 5 for the three dimensions
+                let u1 = halton_sequence(*index, 2);
+                let u2 = halton_sequence(*index, 3);
+                let u3 = halton_sequence(*index, 5);
+                *index += 1;
+
+                let alpha = u1 * 360.0;
+                let beta = (1.0 - u2 * 2.0).acos() * 180.0 / PI;
+                let gamma = u3 * 360.0;
+                Some(Euler::new(alpha, beta, gamma))
+            }
         }
     }
 
@@ -365,6 +443,9 @@ impl OrientationSampler {
                 };
             }
             Self::Discrete { index, .. } => {
+                *index = 0;
+            }
+            Self::Sobol { index, .. } | Self::Halton { index } => {
                 *index = 0;
             }
         }
@@ -391,6 +472,47 @@ impl Orientations {
                 let gammas: Vec<f32> = eulers.iter().map(|e| e.gamma).collect();
                 Orientations::new_discrete(alphas, betas, gammas).unwrap()
             }
+            Scheme::Sobol { num_orients } => Orientations::sobol(*num_orients, seed),
+            Scheme::Halton { num_orients } => Orientations::halton(*num_orients),
+        }
+    }
+
+    /// Generate orientations using Sobol quasi-random sequence.
+    pub fn sobol(num_orient: usize, seed: Option<u64>) -> Orientations {
+        let seed = seed.unwrap_or(0) as u32;
+        let eulers: Vec<(f32, f32, f32)> = (0..num_orient as u32)
+            .map(|i| {
+                let u1 = sobol_burley::sample(i, 0, seed);
+                let u2 = sobol_burley::sample(i, 1, seed);
+                let u3 = sobol_burley::sample(i, 2, seed);
+                let alpha = u1 * 360.0;
+                let beta = (1.0_f32 - u2 * 2.0).acos() * 180.0 / PI;
+                let gamma = u3 * 360.0;
+                (alpha, beta, gamma)
+            })
+            .collect();
+        Orientations {
+            num_orientations: num_orient,
+            eulers,
+        }
+    }
+
+    /// Generate orientations using Halton quasi-random sequence.
+    pub fn halton(num_orient: usize) -> Orientations {
+        let eulers: Vec<(f32, f32, f32)> = (0..num_orient as u32)
+            .map(|i| {
+                let u1 = halton_sequence(i, 2);
+                let u2 = halton_sequence(i, 3);
+                let u3 = halton_sequence(i, 5);
+                let alpha = u1 * 360.0;
+                let beta = (1.0 - u2 * 2.0).acos() * 180.0 / PI;
+                let gamma = u3 * 360.0;
+                (alpha, beta, gamma)
+            })
+            .collect();
+        Orientations {
+            num_orientations: num_orient,
+            eulers,
         }
     }
 

--- a/src/python.rs
+++ b/src/python.rs
@@ -36,6 +36,20 @@ fn discrete_orientation(eulers: Vec<Euler>) -> PyResult<Scheme> {
     Ok(Scheme::Discrete { eulers })
 }
 
+/// Create a Sobol quasi-random orientation scheme (faster convergence)
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction(module = "goad._goad"))]
+#[pyfunction]
+fn sobol_orientation(num_orients: usize) -> PyResult<Scheme> {
+    Ok(Scheme::Sobol { num_orients })
+}
+
+/// Create a Halton quasi-random orientation scheme (faster convergence)
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction(module = "goad._goad"))]
+#[pyfunction]
+fn halton_orientation(num_orients: usize) -> PyResult<Scheme> {
+    Ok(Scheme::Halton { num_orients })
+}
+
 /// Create an Orientation with uniform scheme and default convention
 #[cfg_attr(feature = "stub-gen", gen_stub_pyfunction(module = "goad._goad"))]
 #[pyfunction]
@@ -60,6 +74,34 @@ fn create_discrete_orientation(
 ) -> PyResult<Orientation> {
     Ok(Orientation {
         scheme: Scheme::Discrete { eulers },
+        euler_convention: euler_convention.unwrap_or(EulerConvention::ZYZ),
+    })
+}
+
+/// Create an Orientation with Sobol quasi-random scheme (faster convergence)
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction(module = "goad._goad"))]
+#[pyfunction]
+#[pyo3(signature = (num_orients, euler_convention = None))]
+fn create_sobol_orientation(
+    num_orients: usize,
+    euler_convention: Option<EulerConvention>,
+) -> PyResult<Orientation> {
+    Ok(Orientation {
+        scheme: Scheme::Sobol { num_orients },
+        euler_convention: euler_convention.unwrap_or(EulerConvention::ZYZ),
+    })
+}
+
+/// Create an Orientation with Halton quasi-random scheme (faster convergence)
+#[cfg_attr(feature = "stub-gen", gen_stub_pyfunction(module = "goad._goad"))]
+#[pyfunction]
+#[pyo3(signature = (num_orients, euler_convention = None))]
+fn create_halton_orientation(
+    num_orients: usize,
+    euler_convention: Option<EulerConvention>,
+) -> PyResult<Orientation> {
+    Ok(Orientation {
+        scheme: Scheme::Halton { num_orients },
         euler_convention: euler_convention.unwrap_or(EulerConvention::ZYZ),
     })
 }
@@ -108,8 +150,12 @@ fn _goad_py(m: &Bound<'_, PyModule>) -> PyResult<()> {
     // Helper functions for orientations
     m.add_function(wrap_pyfunction!(uniform_orientation, m)?)?;
     m.add_function(wrap_pyfunction!(discrete_orientation, m)?)?;
+    m.add_function(wrap_pyfunction!(sobol_orientation, m)?)?;
+    m.add_function(wrap_pyfunction!(halton_orientation, m)?)?;
     m.add_function(wrap_pyfunction!(create_uniform_orientation, m)?)?;
     m.add_function(wrap_pyfunction!(create_discrete_orientation, m)?)?;
+    m.add_function(wrap_pyfunction!(create_sobol_orientation, m)?)?;
+    m.add_function(wrap_pyfunction!(create_halton_orientation, m)?)?;
 
     Ok(())
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -175,9 +175,9 @@ impl Settings {
                 max_tir
             )));
         }
-        // Create default orientation if none provided (single random orientation)
+        // Create default orientation if none provided (single Sobol orientation)
         let orientation = orientation.unwrap_or_else(|| Orientation {
-            scheme: Scheme::Uniform { num_orients: 1 },
+            scheme: Scheme::Sobol { num_orients: 1 },
             euler_convention: DEFAULT_EULER_ORDER,
         });
 

--- a/src/settings/cli.rs
+++ b/src/settings/cli.rs
@@ -109,6 +109,14 @@ pub struct OrientationArgs {
     #[arg(long, value_parser = parse_euler_angles, num_args = 1.., value_delimiter = ' ', group = "orientation")]
     pub discrete: Option<Vec<Euler>>,
 
+    /// Use Sobol quasi-random orientation scheme (faster convergence).
+    #[arg(long, group = "orientation")]
+    pub sobol: Option<usize>,
+
+    /// Use Halton quasi-random orientation scheme (faster convergence).
+    #[arg(long, group = "orientation")]
+    pub halton: Option<usize>,
+
     /// Specify Euler angle convention for orientation.
     #[arg(long, value_parser = parse_euler_convention)]
     pub euler: Option<EulerConvention>,
@@ -289,6 +297,24 @@ pub fn update_settings_from_cli(config: &mut Settings) {
         );
         config.orientation = Orientation {
             scheme: Scheme::Discrete { eulers },
+            euler_convention,
+        };
+    } else if let Some(num_orients) = args.orientation.sobol {
+        trace!(
+            "config updated from cli arg: orientation = Sobol {{ num_orients: {} }}",
+            num_orients
+        );
+        config.orientation = Orientation {
+            scheme: Scheme::Sobol { num_orients },
+            euler_convention,
+        };
+    } else if let Some(num_orients) = args.orientation.halton {
+        trace!(
+            "config updated from cli arg: orientation = Halton {{ num_orients: {} }}",
+            num_orients
+        );
+        config.orientation = Orientation {
+            scheme: Scheme::Halton { num_orients },
             euler_convention,
         };
     } else if let Some(convention) = args.orientation.euler {

--- a/tests/orientation_sampling_tests.rs
+++ b/tests/orientation_sampling_tests.rs
@@ -1,0 +1,243 @@
+//! Tests for orientation sampling methods (Uniform, Sobol, Halton)
+
+use goad::orientation::{OrientationSampler, Orientations, Scheme};
+
+/// Test that Sobol sampler produces deterministic results with same seed
+#[test]
+fn test_sobol_sampler_deterministic() {
+    let mut sampler1 = OrientationSampler::sobol(Some(42));
+    let mut sampler2 = OrientationSampler::sobol(Some(42));
+
+    for _ in 0..10 {
+        let e1 = sampler1.next().unwrap();
+        let e2 = sampler2.next().unwrap();
+        assert_eq!(e1.alpha, e2.alpha);
+        assert_eq!(e1.beta, e2.beta);
+        assert_eq!(e1.gamma, e2.gamma);
+    }
+}
+
+/// Test that Halton sampler produces deterministic results
+#[test]
+fn test_halton_sampler_deterministic() {
+    let mut sampler1 = OrientationSampler::halton();
+    let mut sampler2 = OrientationSampler::halton();
+
+    for _ in 0..10 {
+        let e1 = sampler1.next().unwrap();
+        let e2 = sampler2.next().unwrap();
+        assert_eq!(e1.alpha, e2.alpha);
+        assert_eq!(e1.beta, e2.beta);
+        assert_eq!(e1.gamma, e2.gamma);
+    }
+}
+
+/// Test that different seeds produce different sequences
+#[test]
+fn test_sobol_different_seeds() {
+    let mut sampler1 = OrientationSampler::sobol(Some(1));
+    let mut sampler2 = OrientationSampler::sobol(Some(2));
+
+    let e1 = sampler1.next().unwrap();
+    let e2 = sampler2.next().unwrap();
+
+    // Different seeds should produce different results
+    assert!(e1.alpha != e2.alpha || e1.beta != e2.beta || e1.gamma != e2.gamma);
+}
+
+/// Test that sampler reset works correctly for Sobol
+#[test]
+fn test_sobol_sampler_reset() {
+    let mut sampler = OrientationSampler::sobol(Some(42));
+
+    let first_batch: Vec<_> = (0..5).map(|_| sampler.next().unwrap()).collect();
+
+    sampler.reset();
+
+    let second_batch: Vec<_> = (0..5).map(|_| sampler.next().unwrap()).collect();
+
+    for (e1, e2) in first_batch.iter().zip(second_batch.iter()) {
+        assert_eq!(e1.alpha, e2.alpha);
+        assert_eq!(e1.beta, e2.beta);
+        assert_eq!(e1.gamma, e2.gamma);
+    }
+}
+
+/// Test that sampler reset works correctly for Halton
+#[test]
+fn test_halton_sampler_reset() {
+    let mut sampler = OrientationSampler::halton();
+
+    let first_batch: Vec<_> = (0..5).map(|_| sampler.next().unwrap()).collect();
+
+    sampler.reset();
+
+    let second_batch: Vec<_> = (0..5).map(|_| sampler.next().unwrap()).collect();
+
+    for (e1, e2) in first_batch.iter().zip(second_batch.iter()) {
+        assert_eq!(e1.alpha, e2.alpha);
+        assert_eq!(e1.beta, e2.beta);
+        assert_eq!(e1.gamma, e2.gamma);
+    }
+}
+
+/// Test that Sobol produces angles in valid ranges
+#[test]
+fn test_sobol_angle_ranges() {
+    let mut sampler = OrientationSampler::sobol(Some(123));
+
+    for _ in 0..100 {
+        let e = sampler.next().unwrap();
+        assert!(
+            e.alpha >= 0.0 && e.alpha <= 360.0,
+            "alpha out of range: {}",
+            e.alpha
+        );
+        assert!(
+            e.beta >= 0.0 && e.beta <= 180.0,
+            "beta out of range: {}",
+            e.beta
+        );
+        assert!(
+            e.gamma >= 0.0 && e.gamma <= 360.0,
+            "gamma out of range: {}",
+            e.gamma
+        );
+    }
+}
+
+/// Test that Halton produces angles in valid ranges
+#[test]
+fn test_halton_angle_ranges() {
+    let mut sampler = OrientationSampler::halton();
+
+    for _ in 0..100 {
+        let e = sampler.next().unwrap();
+        assert!(
+            e.alpha >= 0.0 && e.alpha <= 360.0,
+            "alpha out of range: {}",
+            e.alpha
+        );
+        assert!(
+            e.beta >= 0.0 && e.beta <= 180.0,
+            "beta out of range: {}",
+            e.beta
+        );
+        assert!(
+            e.gamma >= 0.0 && e.gamma <= 360.0,
+            "gamma out of range: {}",
+            e.gamma
+        );
+    }
+}
+
+/// Test batch generation with Sobol scheme
+#[test]
+fn test_orientations_sobol_batch() {
+    let scheme = Scheme::Sobol { num_orients: 100 };
+    let orientations = Orientations::generate(&scheme, Some(42));
+
+    assert_eq!(orientations.num_orientations, 100);
+    assert_eq!(orientations.eulers.len(), 100);
+
+    // Check all angles are in valid ranges
+    for (alpha, beta, gamma) in &orientations.eulers {
+        assert!(*alpha >= 0.0 && *alpha <= 360.0);
+        assert!(*beta >= 0.0 && *beta <= 180.0);
+        assert!(*gamma >= 0.0 && *gamma <= 360.0);
+    }
+}
+
+/// Test batch generation with Halton scheme
+#[test]
+fn test_orientations_halton_batch() {
+    let scheme = Scheme::Halton { num_orients: 100 };
+    let orientations = Orientations::generate(&scheme, None);
+
+    assert_eq!(orientations.num_orientations, 100);
+    assert_eq!(orientations.eulers.len(), 100);
+
+    // Check all angles are in valid ranges
+    for (alpha, beta, gamma) in &orientations.eulers {
+        assert!(*alpha >= 0.0 && *alpha <= 360.0);
+        assert!(*beta >= 0.0 && *beta <= 180.0);
+        assert!(*gamma >= 0.0 && *gamma <= 360.0);
+    }
+}
+
+/// Test that Sobol batch is deterministic with same seed
+#[test]
+fn test_orientations_sobol_deterministic() {
+    let scheme = Scheme::Sobol { num_orients: 50 };
+    let o1 = Orientations::generate(&scheme, Some(999));
+    let o2 = Orientations::generate(&scheme, Some(999));
+
+    assert_eq!(o1.eulers, o2.eulers);
+}
+
+/// Test that Halton batch is deterministic (no seed needed)
+#[test]
+fn test_orientations_halton_deterministic() {
+    let scheme = Scheme::Halton { num_orients: 50 };
+    let o1 = Orientations::generate(&scheme, None);
+    let o2 = Orientations::generate(&scheme, None);
+
+    assert_eq!(o1.eulers, o2.eulers);
+}
+
+/// Test that Sobol and Halton produce different sequences
+#[test]
+fn test_sobol_halton_differ() {
+    let mut sobol = OrientationSampler::sobol(Some(0));
+    let mut halton = OrientationSampler::halton();
+
+    let e_sobol = sobol.next().unwrap();
+    let e_halton = halton.next().unwrap();
+
+    // They should produce different results (extremely unlikely to be equal)
+    assert!(
+        e_sobol.alpha != e_halton.alpha
+            || e_sobol.beta != e_halton.beta
+            || e_sobol.gamma != e_halton.gamma
+    );
+}
+
+/// Test that uniform and quasi-random samplers produce valid orientations
+#[test]
+fn test_all_samplers_valid_orientations() {
+    let samplers: Vec<(&str, OrientationSampler)> = vec![
+        ("uniform", OrientationSampler::uniform(Some(42))),
+        ("sobol", OrientationSampler::sobol(Some(42))),
+        ("halton", OrientationSampler::halton()),
+    ];
+
+    for (name, mut sampler) in samplers {
+        for i in 0..50 {
+            let e = sampler
+                .next()
+                .expect(&format!("{} sampler exhausted at {}", name, i));
+
+            assert!(
+                e.alpha >= 0.0 && e.alpha <= 360.0,
+                "{} alpha out of range at {}: {}",
+                name,
+                i,
+                e.alpha
+            );
+            assert!(
+                e.beta >= 0.0 && e.beta <= 180.0,
+                "{} beta out of range at {}: {}",
+                name,
+                i,
+                e.beta
+            );
+            assert!(
+                e.gamma >= 0.0 && e.gamma <= 360.0,
+                "{} gamma out of range at {}: {}",
+                name,
+                i,
+                e.gamma
+            );
+        }
+    }
+}


### PR DESCRIPTION
- Add sobol_burley dependency for Owen-scrambled Sobol sequences
- Extend Scheme enum with Sobol and Halton variants
- Extend OrientationSampler with sobol() and halton() constructors
- Add halton_sequence() helper function
- Update Orientations::generate() for batch generation
- Update Convergence solver to respect scheme setting
- Add --sobol and --halton CLI flags
- Add Python helper functions and Orientation static methods
- Change default sampling method from Uniform to Sobol
- Add 13 unit tests for new sampling methods

Sobol/Halton sequences converge as O(1/N) vs O(1/sqrt(N)) for pseudo-random